### PR TITLE
Fix name of `ostree container commit` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ COPY --from=builder /build/hello-world /usr/bin
 # And add our unit file
 ADD hello-world.service /etc/systemd/system/hello-world.service
 # Also add strace; the `rm -rf /var/cache` is the equivalent of `yum clean all`.
-# For `ostree container finalize`, see https://github.com/ostreedev/ostree-rs-ext/issues/159
+# For `ostree container commit`, see https://github.com/ostreedev/ostree-rs-ext/issues/159
 RUN rpm-ostree install strace && rm -rf /var/cache && \
   ostree container commit


### PR DESCRIPTION
Fix name of `ostree container commit` command in Dockerfile comment